### PR TITLE
remove unused plguins from ckeditor build

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -21,13 +21,10 @@ import PageBreak from '@ckeditor/ckeditor5-page-break/src/pagebreak.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import PasteFromOffice from '@ckeditor/ckeditor5-paste-from-office/src/pastefromoffice';
 import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough.js';
-import Subscript from '@ckeditor/ckeditor5-basic-styles/src/subscript.js';
-import Superscript from '@ckeditor/ckeditor5-basic-styles/src/superscript.js';
 import Table from '@ckeditor/ckeditor5-table/src/table.js';
 import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
 import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
 import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar.js';
-import TextTransformation from '@ckeditor/ckeditor5-typing/src/texttransformation.js';
 import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline.js';
 
 class Editor extends DecoupledDocumentEditor {}
@@ -52,13 +49,10 @@ Editor.builtinPlugins = [
 	Paragraph,
 	PasteFromOffice,
 	Strikethrough,
-	Subscript,
-	Superscript,
 	Table,
 	TableCellProperties,
 	TableProperties,
 	TableToolbar,
-	TextTransformation,
 	Underline
 ];
 


### PR DESCRIPTION
What?
CKEditor build cleanup 

Why?
To minimise build size 

I have installed webpack bundle analyser in this repo to see the diff in my local
removing 3 unused plugins doesn't reduce much bundle size :( 

Before 
![ckeditor_build_before](https://user-images.githubusercontent.com/84690835/131783131-b78685de-d3df-4d9e-939a-25b65c797718.png)

After removing
![ckeditor_build_after_removing](https://user-images.githubusercontent.com/84690835/131783142-5495a3be-2d6d-4490-8fa9-6141976be229.png)

